### PR TITLE
use dot notation to access x,y elements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ pyslobs/__pycache__/
 PySLOBS.egg-info/
 
 progress.xlsx
+
+venv

--- a/examples/spin.py
+++ b/examples/spin.py
@@ -7,10 +7,10 @@ import logging
 import math
 
 from pyslobs import (
-    SlobsConnection,
-    ScenesService,
     ITransform,
     IVec2,
+    ScenesService,
+    SlobsConnection,
     config_from_ini_else_stdin,
 )
 
@@ -39,8 +39,8 @@ class Spinnable:
         self.original_transform = transform
         self.original_size = size
         self.center = (
-            int(size[0] * transform.scale["x"] / 2),
-            int(size[1] * transform.scale["y"] / 2),
+            int(size[0] * transform.scale.x / 2),
+            int(size[1] * transform.scale.y / 2),
         )
         self.hypotenuse_len = math.sqrt(self.center[0] ** 2 + self.center[1] ** 2)
         self.original_center_angle_rad = math.atan(self.center[1] / self.center[0])
@@ -61,8 +61,8 @@ class Spinnable:
             crop=self.original_transform.crop,
             scale=self.original_transform.scale,
             position=IVec2(
-                x=self.original_transform.position["x"] + offset[0],
-                y=self.original_transform.position["y"] + offset[1],
+                x=self.original_transform.position.x + offset[0],
+                y=self.original_transform.position.y + offset[1],
             ),
             rotation=self.original_transform.rotation + angle_deg,
         )


### PR DESCRIPTION
Hi!

When running spin example I was getting error:

```python
ITransform(crop=ICrop(bottom=0, left=0, right=0, top=0), position=IVec2(x=0, y=0), rotation=0, scale=IVec2(x=6.198979591836735, y=6.198979591836735))
ERROR:root:Unexpected exception
Traceback (most recent call last):
  File "F:\Github\PySLOBS\examples\spin.py", line 86, in spin
    Spinnable(item, item.transform, (source.width, source.height))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "F:\Github\PySLOBS\examples\spin.py", line 43, in __init__
    int(size[0] * transform.scale["x"] / 2),
                  ~~~~~~~~~~~~~~~^^^^^
TypeError: tuple indices must be integers or slices, not str
```

I noticed transform.scale and transform.position are namedtuples. Swapping for dot notation cleared the error.

Thanks for your time.